### PR TITLE
Add endpoint to get employee appointments for a specific day

### DIFF
--- a/src/modules/employees/employees.controller.js
+++ b/src/modules/employees/employees.controller.js
@@ -191,3 +191,41 @@ exports.getSchedule = async (req, res) => {
     });
   }
 };
+
+// Get appointments for a specific day for the authenticated employee
+exports.getAppointmentsForDay = async (req, res) => {
+  try {
+    // req.user is set by verifyToken() middleware
+    const id_user = req.user?.id_user;
+    const date = req.query.date;
+
+    const result = await service.getAppointmentsForDay(id_user, date);
+
+      // If there are no appointments, return an informative message but still 200
+      if (!result || !Array.isArray(result.rows) || result.total === 0) {
+        return res.status(200).json({
+          success: true,
+          message: 'No appointments found for the specified date',
+          data: [],
+          total: 0
+        });
+      }
+
+      res.status(200).json({
+        success: true,
+        message: 'Appointments retrieved successfully',
+        data: result.rows,
+        total: result.total
+      });
+  } catch (error) {
+    console.error('Error getting appointments for day:', error);
+    // Basic error mapping
+    if (error.message && (error.message.includes('required') || error.message.includes('Invalid'))) {
+      return res.status(400).json({ success: false, message: error.message });
+    }
+    if (error.message && error.message.toLowerCase().includes('not found')) {
+      return res.status(404).json({ success: false, message: error.message });
+    }
+    res.status(500).json({ success: false, message: error.message });
+  }
+};

--- a/src/modules/employees/employees.db.js
+++ b/src/modules/employees/employees.db.js
@@ -87,6 +87,26 @@ exports.getEmployeeById = async (id) => {
   }
 };
 
+// Get employee by user id
+exports.getEmployeeByUserId = async (id_user) => {
+  const conn = await createConnection();
+  try {
+    const [rows] = await conn.execute(
+      `SELECT e.id_employee, e.id_branch, e.id_user, e.availability,
+              u.name, u.last_name, u.email, u.phone,
+              br.name AS branch_name
+       FROM \`Employee\` e
+       INNER JOIN \`User\` u ON e.id_user = u.id_user
+       LEFT JOIN \`Branch\` br ON e.id_branch = br.id_branch
+       WHERE e.id_user = ? LIMIT 1`,
+      [id_user]
+    );
+    return rows[0] || null;
+  } finally {
+    await conn.end();
+  }
+};
+
 // Update employee
 exports.updateEmployee = async (id, employee) => {
   const conn = await createConnection();

--- a/src/modules/employees/employees.routes.js
+++ b/src/modules/employees/employees.routes.js
@@ -8,6 +8,11 @@ const verifyToken = require('../../utils/services/verifyToken');
 // These endpoints accept all roles (admin=1, client=2, employee=3)
 router.get('/business/:id_business', verifyToken(), controller.listEmployeesByBusiness);
 router.get('/branch/:id_branch', verifyToken(), controller.listEmployeesByBranch);
+// Get appointments for authenticated employee for a specific day (query param: date=YYYY-MM-DD)
+// Allow both /appointments and /me/appointments so clients calling the more-explicit path
+// don't accidentally match the '/:id' admin-protected route.
+router.get('/appointments', verifyToken.verifyEmployee ? verifyToken.verifyEmployee() : verifyToken(), controller.getAppointmentsForDay);
+router.get('/me/appointments', verifyToken.verifyEmployee ? verifyToken.verifyEmployee() : verifyToken(), controller.getAppointmentsForDay);
 
 // CRUD endpoints
 router.post('/', verifyAdmin(), controller.createEmployee);

--- a/src/modules/employees/employees.service.js
+++ b/src/modules/employees/employees.service.js
@@ -1,4 +1,5 @@
 const db = require('./employees.db');
+const appointmentsDb = require('../appointments/appointments.db');
 const { Employee, availabilityToColor } = require('./employees.model');
 
 // Create employee with validation
@@ -205,4 +206,31 @@ exports.getSchedule = async (id_employee) => {
   }
 
   return await db.getSchedule(id_employee);
+};
+
+// Get appointments for a specific day for the employee that belongs to the given user id
+exports.getAppointmentsForDay = async (id_user, date) => {
+  if (!id_user) {
+    throw new Error('User ID is required');
+  }
+  if (!date) {
+    throw new Error('Date is required');
+  }
+
+  // basic YYYY-MM-DD validation
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+    throw new Error('Invalid date format. Use YYYY-MM-DD');
+  }
+
+  // Find employee by user id
+  const employee = await db.getEmployeeByUserId(id_user);
+  // If the user is not associated to an Employee record, return empty result
+  // instead of throwing so the client receives an empty appointments list.
+  if (!employee) {
+    return { rows: [], total: 0 };
+  }
+
+  // Use appointments module to list appointments for that employee on the given date
+  const result = await appointmentsDb.listAppointments({ id_employee: employee.id_employee, date });
+  return result;
 };

--- a/src/utils/services/verifyToken.js
+++ b/src/utils/services/verifyToken.js
@@ -41,5 +41,31 @@ function verifyAdmin(origin = null) {
   };
 }
 
+// Middleware to verify employee role (id_rol === 3)
+function verifyEmployee(origin = null) {
+  return (req, res, next) => {
+    const user = getAuthUser(req, origin);
+
+    if (!user) {
+      return res.status(401).json({
+        success: false,
+        message: "Unauthorized: Invalid or expired token"
+      });
+    }
+
+    // Check if user has employee role (id_rol === 3)
+    if (user.id_rol !== 3) {
+      return res.status(403).json({
+        success: false,
+        message: "Forbidden: Employee access required"
+      });
+    }
+
+    req.user = user;
+    next();
+  };
+}
+
 module.exports = verifyToken;
 module.exports.verifyAdmin = verifyAdmin;
+module.exports.verifyEmployee = verifyEmployee;


### PR DESCRIPTION


## 🚀 Description
*Introduces a new route and controller method to allow authenticated employees to retrieve their appointments for a given date. Adds service and database logic to fetch appointments by user ID and date, and includes middleware to restrict access to users with the employee role.*

## 📌 Related Issue

## 🛠️ Changes Made
- [x] New feature
- [ ] Bug fixes
- [ ] Code refactoring
- [ ] Documentation updates

## 🔎 How to Test the Changes?
1. go to insomnia
2. test the endpoint "/employees/me/appoiments(listar todas las citas de un employee, de ése dia)"
3. get a valid JWT with rol 3 (employee)

## ✅ Checklist
- [ ] Tests pass
- [x] Reviewed by at least 1 team member
- [ ] UI/UX reviewed (if applicable)
- [ ] Documentation updated

## Screenshots (if applicable)
*Add relevant screenshots here...*
<img width="1896" height="997" alt="imagen" src="https://github.com/user-attachments/assets/d4b10baa-d826-4e28-95e3-d10eceb15c89" />

