### PR TITLE
Enforce business creation limits per subscription plan

### DIFF
--- a/jobbi_db(3).sql
+++ b/jobbi_db(3).sql
@@ -178,7 +178,8 @@ INSERT INTO `CharacteristicsPlans` (`id_characteristics`, `description`) VALUES
 (3, 'Máximo 2 sucursales'),
 (4, 'Máximo 10 empleados por sucursal'),
 (5, 'Sucursales ilimitadas'),
-(6, 'Empleados ilimitados');
+(6, 'Empleados ilimitados'),
+(7, 'Máximo 1 negocio');
 
 -- --------------------------------------------------------
 
@@ -328,6 +329,7 @@ CREATE TABLE `PlanCharacteristics` (
 INSERT INTO `PlanCharacteristics` (`id_plan`, `id_characteristics`) VALUES
 (1, 1),
 (1, 2),
+(1, 7),
 (2, 3),
 (2, 4),
 (3, 5),

--- a/src/modules/business/business.controller.js
+++ b/src/modules/business/business.controller.js
@@ -1,9 +1,22 @@
 const businessService = require('./business.service');
+const subscriptionService = require('../subscriptions/subscriptions.service');
 
 exports.createBusiness = async (req, res) => {
   try {
     const userId = req.user.id_user;
     const businessData = req.body;
+
+    // Validate business limit before creating
+    const validation = await subscriptionService.canCreateBusiness(userId);
+    if (!validation.allowed) {
+      return res.status(403).json({
+        success: false,
+        message: validation.message,
+        reason: validation.reason,
+        currentCount: validation.currentCount,
+        limit: validation.limit
+      });
+    }
 
     const result = await businessService.createBusinessFlow(userId, businessData);
 

--- a/src/modules/subscriptions/subscriptions.controller.js
+++ b/src/modules/subscriptions/subscriptions.controller.js
@@ -79,6 +79,23 @@ exports.getMyPlanUsage = async (req, res) => {
 };
 
 /**
+ * Check if the authenticated admin can create a business
+ */
+exports.canCreateBusiness = async (req, res) => {
+  try {
+    if (!req.user || req.user.id_rol != 1) {
+      return res.status(403).json({ success: false, message: 'Forbidden: Admin access required' });
+    }
+
+    const validation = await subscriptionService.canCreateBusiness(req.user.id_user);
+    res.status(200).json({ success: true, data: validation });
+  } catch (error) {
+    console.error('Error checking business creation:', error);
+    res.status(500).json({ success: false, message: error.message });
+  }
+};
+
+/**
  * Check if the authenticated admin can create a branch
  */
 exports.canCreateBranch = async (req, res) => {

--- a/src/modules/subscriptions/subscriptions.db.js
+++ b/src/modules/subscriptions/subscriptions.db.js
@@ -27,8 +27,13 @@ async function getPlanCharacteristics(planId) {
 
 function limitsFromCharacteristics(characteristics) {
   // Default: no limits defined
+  let maxBusinesses = null; // null means unlimited
   let maxBranches = null; // null means unlimited
   let maxEmployeesPerBranch = null;
+
+  // Characteristic IDs for business limits (assuming ID 7 for 1 business limit)
+  if (characteristics.includes(7)) maxBusinesses = 1;
+  // Add more business limit characteristics if needed
 
   if (characteristics.includes(1)) maxBranches = 1;
   if (characteristics.includes(3)) maxBranches = 2;
@@ -38,7 +43,7 @@ function limitsFromCharacteristics(characteristics) {
   if (characteristics.includes(4)) maxEmployeesPerBranch = 10;
   if (characteristics.includes(6)) maxEmployeesPerBranch = null; // unlimited
 
-  return { maxBranches, maxEmployeesPerBranch };
+  return { maxBusinesses, maxBranches, maxEmployeesPerBranch };
 }
 
 async function getPlanLimits(planId) {
@@ -157,6 +162,21 @@ async function getBranchesForAdmin(userId) {
   }
 }
 
+async function countBusinessesForAdmin(userId) {
+  const conn = await createConnection();
+  try {
+    const [rows] = await conn.execute(
+      `SELECT COUNT(*) as total
+       FROM Business
+       WHERE id_user_admin = ? AND state_business = 1`,
+      [userId]
+    );
+    return rows[0]?.total || 0;
+  } finally {
+    await conn.end();
+  }
+}
+
 module.exports = {
   getAllPlans,
   getPlanCharacteristics,
@@ -169,5 +189,6 @@ module.exports = {
   countBranchesForAdmin,
   countEmployeesInBranch,
   getBranchesForAdmin,
+  countBusinessesForAdmin,
   limitsFromCharacteristics,
 };

--- a/src/modules/subscriptions/subscriptions.routes.js
+++ b/src/modules/subscriptions/subscriptions.routes.js
@@ -11,6 +11,15 @@ router.get('/plans', controller.getAllPlans);
 // Admin only: my plan
 router.get('/my-plan', verifyAdmin(), controller.getMyPlan);
 
+// Admin only: check limits
+router.get('/can-create-business', verifyAdmin(), controller.canCreateBusiness);
+router.get('/can-create-branch', verifyAdmin(), controller.canCreateBranch);
+router.get('/can-create-employee', verifyAdmin(), controller.canCreateEmployee);
+
+// Admin only: usage and history
+router.get('/my-usage', verifyAdmin(), controller.getMyPlanUsage);
+router.get('/my-history', verifyAdmin(), controller.getMySubscriptionHistory);
+
 // Admin-protected: assign/change plan
 router.post('/assign', verifyAdmin(), controller.assignPlan);
 router.post('/change', verifyAdmin(), controller.changePlan);


### PR DESCRIPTION


## 🚀 Description
*Added logic to restrict the number of businesses an admin can create based on their subscription plan. Updated database schema and characteristics, controller, service, and routes to support business limit checks and provide relevant API endpoints and error messages.*

## 📌 Related Issue
https://jobbi.atlassian.net/browse/KAN-97
## 🛠️ Changes Made
- [ ] New feature
- [x] Bug fixes
- [ ] Code refactoring
- [ ] Documentation updates

## 🔎 How to Test the Changes?
1. go to insomnia test check that you already have 1 business
2. and try to add another business, the answer will be "{
	"success": false,
	"message": "You already have the maximum number of businesses allowed by your plan.",
	"reason": "business_limit_reached",
	"currentCount": 1,
	"limit": 1
}"

## ✅ Checklist
- [ ] Tests pass
- [x] Reviewed by at least 1 team member
- [ ] UI/UX reviewed (if applicable)
- [ ] Documentation updated

## Screenshots (if applicable)
*Add relevant screenshots here...*

<img width="1787" height="863" alt="imagen" src="https://github.com/user-attachments/assets/acd7799d-4a38-498c-a991-5ce41a684f06" />

